### PR TITLE
add file directives to epicsMMIODef (Linux)

### DIFF
--- a/include/os/Linux/epicsMMIODef.h
+++ b/include/os/Linux/epicsMMIODef.h
@@ -4,8 +4,14 @@
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
-/*
- * Author: Michael Davidsaver <mdavidsaver@bnl.gov>
+/** 
+ * @file epicsMMIODef.h
+ * @brief Memory Mapped I/O
+ *
+ * Definitions related to Memory Mapped I/O
+ *
+ * @author Michael Davidsaver <mdavidsaver@bnl.gov>
+ * @ingroup mmio
  */
 
 #ifndef EPICSMMIODEF_H


### PR DESCRIPTION
This file was doxygenized, but the file directives were missing.

The doxygen build on my system complains:

`/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:160: warning: documentation for unknown define bswap16 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:163: warning: documentation for unknown define bswap32 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:166: warning: documentation for unknown define be_ioread16 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:169: warning: documentation for unknown define be_iowrite16 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:172: warning: documentation for unknown define be_ioread32 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:175: warning: documentation for unknown define be_iowrite32 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:178: warning: documentation for unknown define le_ioread16 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:181: warning: documentation for unknown define le_iowrite16 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:184: warning: documentation for unknown define le_ioread32 found.

/home/rjq35657/epics-codeathon/doxy-libcom/include/os/Linux/epicsMMIODef.h:187: warning: documentation for unknown define le_iowrite32 found.
`